### PR TITLE
Set up a prerender flag on the home page

### DIFF
--- a/sites/all/themes/corporateclean/template.php
+++ b/sites/all/themes/corporateclean/template.php
@@ -87,6 +87,19 @@ function corporateclean_process_page(&$variables) {
   if (module_exists('color')) {
     _color_page_alter($variables);
   }
+
+  if (drupal_is_front_page()) {
+    $element = array(
+      '#type' => 'html_tag',
+      '#tag' => 'link',
+      '#attributes'=> array(
+        'href' => '/content/sample-image-gallery',
+        'rel' => 'prerender',
+      )
+    );
+
+    drupal_add_html_head($element, 'prerender_home');
+  }
  
 }
 


### PR DESCRIPTION
This adds a very simple prerender `link` in the head of the home page of this site to have the client's browser (Chrome and IE11 at the moment) go grab the image gallery page in advance so that it would load much faster.

This logic could be applied in other hooks or other pages for prerendering next content. It is important to only do this if you have really good data which show that the user is likely to take a particular course. See the blog post at https://fourword.fourkitchens.com/article/prerender-chrome-instant-page-loads for more information including an example of the kind of analytics pattern you'd be looking for.
